### PR TITLE
Add smoke test for inventory lookup utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,107 +1,116 @@
-# README.md — Inventory Highlighter Chrome Extension
+# Inventory Highlighter — Chrome Extension
 
-## Overview
-**Inventory Highlighter** is a Chrome extension (Manifest V3) that dims and labels vehicles marked as **Sold** in a Google Sheet directly on dealership inventory pages. It is designed to work on dynamic inventory sites (e.g., Luther Mazda on Dealer Inspire platform) where VINs or Stock Numbers are shown but sold vehicles may still appear online.
-
-- Highlights sold vehicles by dimming them and adding a **Sold / Продано** badge.
-- Works with both **Published CSV** and **Google Sheets API** as a data source.
-- Supports infinite scroll with MutationObserver.
-- Provides an Options page for configuration and a Popup for quick refresh/hide toggle.
+Inventory Highlighter dims and labels sold vehicles directly on dealership inventory pages by cross-checking VIN and Stock numbers against a Google Sheet. It supports both published CSV feeds and the Google Sheets API, and works on infinite-scroll listings.
 
 ## Features
-- **VIN/Stock matching**: Cross‑checks each card’s VIN or Stock number against your Google Sheet.
-- **Dim/Badge**: Sold vehicles are dimmed to ~50% opacity with a top‑right badge.
-- **Hide toggle**: Optionally hide sold vehicles completely.
-- **Auto refresh**: Syncs every N minutes (default: 5) + manual refresh from popup.
-- **Options page**: Configure data source, column names, sold values, selectors, and behavior.
-- **Popup**: Refresh data, toggle hide/show sold, see last sync time.
 
-## Installation
-1. Clone or download this repository.
-2. Open Chrome → `chrome://extensions/`.
-3. Enable **Developer Mode** (top right).
-4. Click **Load unpacked** and select the project root folder.
-5. The extension should now appear in your toolbar.
+- 🔄 **Sheet sync** – Fetches data from either a published CSV URL or the Google Sheets API.
+- 🚗 **VIN / Stock matching** – Normalises VINs and stock numbers, then builds fast lookup sets.
+- ✨ **Visual treatments** – Adds a `Sold` badge and dims matching vehicle cards. Optionally hides them entirely.
+- ♾️ **Infinite scroll aware** – MutationObserver and debounced rescans keep lazy-loaded cards accurate.
+- 🧰 **Customisable** – Options page lets you adjust column names, selectors, sold values, badge text, and refresh cadence.
+- 🧭 **Popup controls** – One-click refresh, hide-sold toggle, and last-sync timestamp.
 
-## Configuration
-1. Click on the extension icon → **Options**.
-2. Choose **Data Source**:
-   - **Published CSV**: Publish your Google Sheet to the web → copy CSV link.
-   - **Sheets API**: Enter Spreadsheet ID, Range, and API Key.
-3. Configure **Columns**:
-   - VIN column header (e.g., `VIN`)
-   - Stock column header (e.g., `Stock`)
-   - Status column header (e.g., `Status`)
-   - Sold values (e.g., `Sold,SOLD,Продано,Delivered`)
-4. Configure **Selectors** (if needed):
-   - Vehicle card selector
-   - VIN selector
-   - Stock selector
-   *(For Luther Mazda, defaults already target Dealer Inspire classes and data attributes.)*
-5. Save settings.
+## Project Structure
+
+```
+manifest.json
+src/
+  background.js       # Service worker: fetches sheets & manages cache/alarms
+  common.js           # Shared helpers and defaults
+  content.js          # Injected on inventory pages to annotate vehicle cards
+  styles.css          # Content script styling (.ih-sold, .ih-badge, .ih-hidden)
+  options/
+    index.html
+    options.css
+    options.js
+  popup/
+    popup.html
+    popup.css
+    popup.js
+```
+
+## Getting Started
+
+1. **Download / Clone** – Grab this repository.
+2. **Provide icons** – Create simple PNG icons at 16px, 48px, and 128px named `icon-16.png`, `icon-48.png`, and `icon-128.png` in an `assets/` folder if you want custom branding.
+3. **Load unpacked** – In Chrome visit `chrome://extensions`, enable Developer Mode, click **Load unpacked**, and pick this folder.
+4. **Configure options** – Right-click the extension → **Options**. Fill in your data source and selectors (see below).
+5. **Visit an inventory page** – The extension will dim and label sold vehicles automatically.
 
 ## Data Source Setup
-### Published CSV (simple)
-1. Open Google Sheet → File → Share → Publish to web → CSV.
-2. Copy the provided URL.
-3. Paste into Options → CSV URL.
 
-### Google Sheets API (advanced)
-1. Enable Sheets API in Google Cloud Console.
-2. Create an API key.
-3. In Options, enter Spreadsheet ID, Range (e.g., `Sheet1!A1:Z1000`), and API Key.
+### Option A: Published CSV (recommended for simplicity)
 
-## Usage
-- Visit an inventory page (e.g., [Luther Mazda Used Vehicles](https://www.luthermazda.com/used-vehicles/)).
-- Sold vehicles (as marked in your sheet) will be dimmed and labeled.
-- Open the popup to:
-  - **Refresh now**: Immediately sync with the sheet.
-  - **Hide sold**: Toggle hiding of sold cards.
-  - **Last sync time**: Shows when data was last updated.
+1. Open your Google Sheet.
+2. Choose **File → Share → Publish to web** and select **Comma-separated values (.csv)**.
+3. Copy the generated URL.
+4. Paste it into **Options → Published CSV URL**.
 
-## Styling
-Injected CSS classes:
-```css
-.ih-sold { filter: grayscale(0.6) opacity(0.6); position: relative; }
-.ih-badge { position:absolute; top:.5rem; right:.5rem; padding:.25rem .5rem; font-weight:600; border-radius:.375rem; background:#000; color:#fff; z-index:10; }
-.ih-hidden { display:none !important; }
+### Option B: Google Sheets API (for private sheets)
+
+1. Enable the Google Sheets API in [Google Cloud Console](https://console.cloud.google.com/apis/library/sheets.googleapis.com).
+2. Create an API key (restrict it to the Sheets API if possible).
+3. Note your Spreadsheet ID (from the sheet URL) and the range containing your data, e.g. `Sheet1!A1:C500`.
+4. In Options fill **Spreadsheet ID**, **Range**, and **API Key**. Leave CSV URL blank.
+
+## Configuring Columns & Status Values
+
+Your sheet must contain the VIN, Stock, and Status columns (case-insensitive). Match the column headers in Options. Add all possible sold-status strings (comma-separated) such as:
+
 ```
+Sold,SOLD,Delivered,Продано
+```
+
+Rows whose status matches any of these values will be treated as sold.
+
+## Selector Customisation
+
+By default the extension targets many Dealer Inspire–style layouts:
+
+- Card selector: `.vehicle-card, .inventory-card, .result-item, .vehicle`
+- VIN selector: `[data-vehicle-vin], [data-vin], .vin`
+- Stock selector: `[data-vehicle-stock], [data-stock], .stock`
+
+If your site uses different markup, update the selectors in Options. Use CSS selectors that resolve relative to each vehicle card.
+
+## Popup Controls
+
+- **Refresh now** – Forces a data fetch via the background service worker.
+- **Hide sold** – Toggles visibility of matched cards (persists per browser profile).
+- **Last sync** – Displays the timestamp of the last successful fetch.
+
+## Styling Hooks
+
+- `.ih-sold` – Applied to sold cards (dims via filter).
+- `.ih-badge` – Badge element appended inside the card.
+- `.ih-hidden` – Applied when hide-sold is enabled.
+
+You can override these classes with custom CSS using a user style manager if desired.
+
+## Permissions
+
+- `storage` – Save configuration and cached sheet data.
+- `alarms` – Schedule periodic refreshes.
+- `host_permissions` – Default includes Google Sheets endpoints and `<all_urls>` for the content script. Restrict hosts before publishing to the Chrome Web Store.
 
 ## Testing Checklist
-- [ ] CSV & Sheets API both fetch data.
-- [ ] VIN/Stock extraction works on target site.
-- [ ] Infinite scroll updates properly.
-- [ ] Popup refresh triggers DOM updates.
-- [ ] Options persist after reload.
-- [ ] Hide Sold toggle works.
 
-## Repo Structure
-```
-/ (root)
-  ├─ manifest.json
-  ├─ README.md
-  ├─ src/
-  │   ├─ background.js
-  │   ├─ content.js
-  │   ├─ common.js
-  │   ├─ styles.css
-  │   ├─ options/
-  │   │   ├─ index.html
-  │   │   ├─ options.js
-  │   └─ popup/
-  │       ├─ popup.html
-  │       ├─ popup.js
-  └─ assets/
-      └─ icon-16.png, icon-48.png, icon-128.png
-```
+- [ ] Options save and reload correctly.
+- [ ] CSV fetch works with a demo sheet (VIN `JM3KK1WY0R1100001`, Status `Sold`).
+- [ ] Sheets API fetch works with API credentials.
+- [ ] Visiting an inventory page dims/badges sold vehicles.
+- [ ] Lazy-loaded cards are annotated after scrolling.
+- [ ] Popup **Refresh now** updates last sync without reloading the page.
+- [ ] Hide sold toggle in the popup hides/unhides cards instantly.
+- [ ] (Optional) Run the local smoke test via `node tests/smoke.mjs` to validate CSV parsing and lookup generation.
 
-## Notes for Luther Mazda (Dealer Inspire)
-- **Allowed host**: `https://*.luthermazda.com/*`
-- **Card selectors**: `.di-vehicle-card, .inventory-card, .vehicle-card, li.vehicle-card, .result-item, .vehicle, .inventory`
-- **VIN selectors**: `[data-vehicle-vin], [data-vin], .vin`
-- **Stock selectors**: `[data-vehicle-stock], [data-stock], .stock`
-- **Regex fallback**: VIN `\b[A-HJ-NPR-Z0-9]{17}\b` | Stock `\b(?:Stock|Stk|Сток|Склад)[:#\s]*([A-Z0-9-]{4,})\b`
+## Packaging & Deployment
+
+1. Update **host_permissions** in `manifest.json` to the exact dealership domains you support.
+2. Run through the testing checklist above.
+3. Add your own PNG icons (16/48/128px) before publishing, then zip the entire folder and upload to the Chrome Web Store developer dashboard.
 
 ## License
-MIT License
 
+MIT License.

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # Inventory Highlighter — Chrome Extension
 
-Inventory Highlighter dims and labels sold vehicles directly on dealership inventory pages by cross-checking VIN and Stock numbers against a Google Sheet. It supports both published CSV feeds and the Google Sheets API, and works on infinite-scroll listings.
+Inventory Highlighter dims and labels sold vehicles directly on dealership inventory pages by cross-checking Stock numbers (and optionally VINs) against a Google Sheet. It supports both published CSV feeds and the Google Sheets API, and works on infinite-scroll listings.
 
 ## Features
 
 - 🔄 **Sheet sync** – Fetches data from either a published CSV URL or the Google Sheets API.
-- 🚗 **VIN / Stock matching** – Normalises VINs and stock numbers, then builds fast lookup sets.
+- 🚗 **Stock matching** – Normalises stock numbers (and VINs if configured), then builds fast lookup sets.
 - ✨ **Visual treatments** – Adds a `Sold` badge and dims matching vehicle cards. Optionally hides them entirely.
 - ♾️ **Infinite scroll aware** – MutationObserver and debounced rescans keep lazy-loaded cards accurate.
 - 🧰 **Customisable** – Options page lets you adjust column names, selectors, sold values, badge text, and refresh cadence.
@@ -51,15 +51,15 @@ src/
 
 1. Enable the Google Sheets API in [Google Cloud Console](https://console.cloud.google.com/apis/library/sheets.googleapis.com).
 2. Create an API key (restrict it to the Sheets API if possible).
-3. Note your Spreadsheet ID (from the sheet URL) and the range containing your data, e.g. `Sheet1!A1:C500`.
+3. Note your Spreadsheet ID (from the sheet URL) and the range containing your data, e.g. `Sheet1!A1:G500`.
 4. In Options fill **Spreadsheet ID**, **Range**, and **API Key**. Leave CSV URL blank.
 
 ## Configuring Columns & Status Values
 
-Your sheet must contain the VIN, Stock, and Status columns (case-insensitive). Match the column headers in Options. Add all possible sold-status strings (comma-separated) such as:
+At minimum your sheet must contain the Stock column (default header `Stock`) and a status column (default header `Comment`). If you also track VINs you can provide that column name, but it is optional. Match the column headers in Options. Add all possible sold-status strings (comma-separated) such as:
 
 ```
-Sold,SOLD,Delivered,Продано
+sold
 ```
 
 Rows whose status matches any of these values will be treated as sold.
@@ -69,8 +69,9 @@ Rows whose status matches any of these values will be treated as sold.
 By default the extension targets many Dealer Inspire–style layouts:
 
 - Card selector: `.vehicle-card, .inventory-card, .result-item, .vehicle`
-- VIN selector: `[data-vehicle-vin], [data-vin], .vin`
 - Stock selector: `[data-vehicle-stock], [data-stock], .stock`
+
+If you need VIN support, provide a VIN selector and column name in the Options page.
 
 If your site uses different markup, update the selectors in Options. Use CSS selectors that resolve relative to each vehicle card.
 
@@ -97,7 +98,7 @@ You can override these classes with custom CSS using a user style manager if des
 ## Testing Checklist
 
 - [ ] Options save and reload correctly.
-- [ ] CSV fetch works with a demo sheet (VIN `JM3KK1WY0R1100001`, Status `Sold`).
+- [ ] CSV fetch works with a demo sheet (Stock `STK-001`, Comment `sold`).
 - [ ] Sheets API fetch works with API credentials.
 - [ ] Visiting an inventory page dims/badges sold vehicles.
 - [ ] Lazy-loaded cards are annotated after scrolling.

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,32 @@
+{
+  "manifest_version": 3,
+  "name": "Inventory Highlighter",
+  "version": "1.0.0",
+  "description": "Dims and labels sold vehicles on dealership inventory pages by syncing with a Google Sheet.",
+  "permissions": [
+    "storage",
+    "alarms"
+  ],
+  "host_permissions": [
+    "https://docs.google.com/*",
+    "https://docs.googleusercontent.com/*",
+    "https://sheets.googleapis.com/*",
+    "<all_urls>"
+  ],
+  "background": {
+    "service_worker": "src/background.js",
+    "type": "module"
+  },
+  "content_scripts": [
+    {
+      "matches": ["<all_urls>"],
+      "js": ["src/content.js"],
+      "css": ["src/styles.css"],
+      "run_at": "document_idle"
+    }
+  ],
+  "options_page": "src/options/index.html",
+  "action": {
+    "default_popup": "src/popup/popup.html"
+  }
+}

--- a/src/background.js
+++ b/src/background.js
@@ -1,0 +1,124 @@
+import {
+  DEFAULT_SETTINGS,
+  STORAGE_KEYS,
+  buildLookups,
+  createStatusMessage,
+  getSettings,
+  saveCache,
+  parseCsv
+} from './common.js';
+
+const ALARM_NAME = 'ih_refresh_alarm';
+
+chrome.runtime.onInstalled.addListener(async () => {
+  await ensureAlarm();
+  await refreshData();
+});
+
+chrome.runtime.onStartup.addListener(async () => {
+  await ensureAlarm();
+  await refreshData();
+});
+
+chrome.alarms.onAlarm.addListener(async (alarm) => {
+  if (alarm.name === ALARM_NAME) {
+    await refreshData();
+  }
+});
+
+chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+  if (message?.type === 'ih_refresh_now') {
+    refreshData()
+      .then((result) => sendResponse({ success: true, ...result }))
+      .catch((error) => sendResponse({ success: false, error: createStatusMessage(error) }));
+    return true;
+  }
+  if (message?.type === 'ih_get_last_sync') {
+    chrome.storage.local
+      .get({ [STORAGE_KEYS.LAST_SYNC]: 0 })
+      .then((result) => sendResponse({ lastSync: result[STORAGE_KEYS.LAST_SYNC] || 0 }))
+      .catch((error) => sendResponse({ lastSync: 0, error: createStatusMessage(error) }));
+    return true;
+  }
+  return undefined;
+});
+
+chrome.storage.onChanged.addListener(async (changes, areaName) => {
+  if (areaName === 'sync' && changes[STORAGE_KEYS.SETTINGS]) {
+    await ensureAlarm();
+    await refreshData();
+  }
+});
+
+async function ensureAlarm() {
+  const settings = await getSettings();
+  const minutes = Math.max(1, Number(settings.autoRefreshMinutes) || DEFAULT_SETTINGS.autoRefreshMinutes);
+  const existing = await chrome.alarms.get(ALARM_NAME);
+  if (existing) {
+    await chrome.alarms.clear(ALARM_NAME);
+  }
+  await chrome.alarms.create(ALARM_NAME, {
+    periodInMinutes: minutes,
+    delayInMinutes: 0.1
+  });
+}
+
+async function refreshData() {
+  const settings = await getSettings();
+  const { dataSource } = settings;
+  try {
+    const rows = await fetchRows(settings, dataSource);
+    const { vinSet, stockSet } = buildLookups(rows, settings);
+    const lastSync = Date.now();
+    await saveCache({ vins: vinSet, stocks: stockSet, lastSync });
+    chrome.runtime.sendMessage({ type: 'ih_cache_updated', lastSync }).catch(() => {});
+    return { lastSync, count: rows.length };
+  } catch (error) {
+    console.error('Inventory Highlighter refresh failed', error);
+    return { error: createStatusMessage(error) };
+  }
+}
+
+async function fetchRows(settings, dataSource) {
+  if (dataSource === 'sheets') {
+    return fetchFromSheets(settings);
+  }
+  return fetchFromCsv(settings);
+}
+
+async function fetchFromCsv(settings) {
+  if (!settings.csvUrl) {
+    throw new Error('CSV URL is not configured.');
+  }
+  const response = await fetch(settings.csvUrl, {
+    cache: 'no-store'
+  });
+  if (!response.ok) {
+    throw new Error(`CSV request failed: ${response.status} ${response.statusText}`);
+  }
+  const text = await response.text();
+  return parseCsv(text);
+}
+
+async function fetchFromSheets(settings) {
+  const { sheets } = settings;
+  if (!sheets.spreadsheetId || !sheets.range || !sheets.apiKey) {
+    throw new Error('Sheets API requires Spreadsheet ID, Range, and API Key.');
+  }
+  const url = new URL(`https://sheets.googleapis.com/v4/spreadsheets/${sheets.spreadsheetId}/values/${encodeURIComponent(sheets.range)}`);
+  url.searchParams.set('key', sheets.apiKey);
+  const response = await fetch(url.toString(), { cache: 'no-store' });
+  if (!response.ok) {
+    throw new Error(`Sheets API request failed: ${response.status} ${response.statusText}`);
+  }
+  const data = await response.json();
+  const [headers, ...rows] = data.values || [];
+  if (!headers) return [];
+  return rows.map((values) => {
+    const row = {};
+    headers.forEach((header, index) => {
+      row[header] = (values[index] || '').trim();
+    });
+    return row;
+  });
+}

--- a/src/common.js
+++ b/src/common.js
@@ -5,18 +5,18 @@ export const DEFAULT_SETTINGS = {
   csvUrl: '',
   sheets: {
     spreadsheetId: '',
-    range: 'Sheet1!A:C',
+    range: 'Sheet1!A:G',
     apiKey: ''
   },
   columns: {
-    vin: 'VIN',
+    vin: '',
     stock: 'Stock',
-    status: 'Status'
+    status: 'Comment'
   },
-  soldValues: ['Sold', 'SOLD'],
+  soldValues: ['sold'],
   selectors: {
     card: '.vehicle-card, .inventory-card, .result-item, .vehicle',
-    vin: '[data-vehicle-vin], [data-vin], .vin',
+    vin: '',
     stock: '[data-vehicle-stock], [data-stock], .stock'
   },
   badgeText: 'Sold',
@@ -112,12 +112,20 @@ export function buildLookups(rows, { columns, soldValues }) {
   const soldStatuses = new Set(soldValues.map((s) => s.trim().toUpperCase()).filter(Boolean));
   const vinSet = new Set();
   const stockSet = new Set();
+  const vinKey = (columns?.vin || '').trim();
+  const stockKey = (columns?.stock || '').trim();
+  const statusKey = (columns?.status || '').trim();
+  if (!statusKey || !stockKey) {
+    return { vinSet, stockSet };
+  }
   rows.forEach((row) => {
-    const statusValue = (row[columns.status] || '').trim().toUpperCase();
+    const statusValue = (row[statusKey] || '').trim().toUpperCase();
     if (!soldStatuses.has(statusValue)) return;
-    const vin = normalizeVin(row[columns.vin] || '');
-    const stock = normalizeStock(row[columns.stock] || '');
-    if (vin) vinSet.add(vin);
+    if (vinKey) {
+      const vin = normalizeVin(row[vinKey] || '');
+      if (vin) vinSet.add(vin);
+    }
+    const stock = normalizeStock(row[stockKey] || '');
     if (stock) stockSet.add(stock);
   });
   return { vinSet, stockSet };

--- a/src/common.js
+++ b/src/common.js
@@ -1,0 +1,153 @@
+// Common utilities shared by background, content, popup, and options scripts.
+
+export const DEFAULT_SETTINGS = {
+  dataSource: 'csv', // 'csv' or 'sheets'
+  csvUrl: '',
+  sheets: {
+    spreadsheetId: '',
+    range: 'Sheet1!A:C',
+    apiKey: ''
+  },
+  columns: {
+    vin: 'VIN',
+    stock: 'Stock',
+    status: 'Status'
+  },
+  soldValues: ['Sold', 'SOLD'],
+  selectors: {
+    card: '.vehicle-card, .inventory-card, .result-item, .vehicle',
+    vin: '[data-vehicle-vin], [data-vin], .vin',
+    stock: '[data-vehicle-stock], [data-stock], .stock'
+  },
+  badgeText: 'Sold',
+  hideSold: false,
+  autoRefreshMinutes: 5
+};
+
+export const STORAGE_KEYS = {
+  SETTINGS: 'ih_settings',
+  CACHE: 'ih_cache',
+  LAST_SYNC: 'ih_last_sync',
+  HIDE_SOLD: 'ih_hide_sold'
+};
+
+export function normalizeVin(vin = '') {
+  return vin
+    .toUpperCase()
+    .replace(/[^A-Z0-9]/g, '')
+    .replace(/[IOQ]/g, '');
+}
+
+export function normalizeStock(stock = '') {
+  return stock.trim().toUpperCase();
+}
+
+export function parseCsv(text) {
+  const lines = text.trim().split(/\r?\n/);
+  if (!lines.length) return [];
+  const headers = lines[0].split(',').map((h) => h.trim());
+  return lines.slice(1).map((line) => {
+    const values = line.split(',');
+    const row = {};
+    headers.forEach((header, index) => {
+      row[header] = (values[index] || '').trim();
+    });
+    return row;
+  });
+}
+
+export async function getSettings() {
+  const { [STORAGE_KEYS.SETTINGS]: stored } = await chrome.storage.sync.get({
+    [STORAGE_KEYS.SETTINGS]: DEFAULT_SETTINGS
+  });
+  return { ...DEFAULT_SETTINGS, ...stored, sheets: { ...DEFAULT_SETTINGS.sheets, ...(stored?.sheets || {}) }, columns: { ...DEFAULT_SETTINGS.columns, ...(stored?.columns || {}) }, selectors: { ...DEFAULT_SETTINGS.selectors, ...(stored?.selectors || {}) } };
+}
+
+export async function saveSettings(settings) {
+  await chrome.storage.sync.set({
+    [STORAGE_KEYS.SETTINGS]: settings
+  });
+}
+
+export async function getCache() {
+  const result = await chrome.storage.local.get({
+    [STORAGE_KEYS.CACHE]: { vins: [], stocks: [] },
+    [STORAGE_KEYS.LAST_SYNC]: 0
+  });
+  return {
+    vins: new Set(result[STORAGE_KEYS.CACHE]?.vins || []),
+    stocks: new Set(result[STORAGE_KEYS.CACHE]?.stocks || []),
+    lastSync: result[STORAGE_KEYS.LAST_SYNC] || 0
+  };
+}
+
+export async function saveCache({ vins, stocks, lastSync }) {
+  await chrome.storage.local.set({
+    [STORAGE_KEYS.CACHE]: {
+      vins: Array.from(vins || []),
+      stocks: Array.from(stocks || [])
+    },
+    [STORAGE_KEYS.LAST_SYNC]: lastSync || Date.now()
+  });
+}
+
+export async function getHideSold() {
+  const { [STORAGE_KEYS.HIDE_SOLD]: hideSold } = await chrome.storage.local.get({
+    [STORAGE_KEYS.HIDE_SOLD]: null
+  });
+  if (hideSold === null || hideSold === undefined) {
+    const settings = await getSettings();
+    return settings.hideSold;
+  }
+  return hideSold;
+}
+
+export async function setHideSold(value) {
+  await chrome.storage.local.set({
+    [STORAGE_KEYS.HIDE_SOLD]: value
+  });
+}
+
+export function buildLookups(rows, { columns, soldValues }) {
+  const soldStatuses = new Set(soldValues.map((s) => s.trim().toUpperCase()).filter(Boolean));
+  const vinSet = new Set();
+  const stockSet = new Set();
+  rows.forEach((row) => {
+    const statusValue = (row[columns.status] || '').trim().toUpperCase();
+    if (!soldStatuses.has(statusValue)) return;
+    const vin = normalizeVin(row[columns.vin] || '');
+    const stock = normalizeStock(row[columns.stock] || '');
+    if (vin) vinSet.add(vin);
+    if (stock) stockSet.add(stock);
+  });
+  return { vinSet, stockSet };
+}
+
+export function createStatusMessage(error) {
+  if (!error) return 'OK';
+  if (error.message) return error.message;
+  try {
+    return JSON.stringify(error);
+  } catch (jsonError) {
+    return String(error);
+  }
+}
+
+export function debounce(fn, delay) {
+  let timer = null;
+  return function debounced(...args) {
+    if (timer) {
+      clearTimeout(timer);
+    }
+    timer = setTimeout(() => {
+      fn.apply(this, args);
+    }, delay);
+  };
+}
+
+export function formatTime(timestamp) {
+  if (!timestamp) return 'Never';
+  const date = new Date(timestamp);
+  if (Number.isNaN(date.getTime())) return 'Invalid date';
+  return date.toLocaleString();
+}

--- a/src/content.js
+++ b/src/content.js
@@ -1,0 +1,164 @@
+(async () => {
+  const {
+    STORAGE_KEYS,
+    getCache,
+    getSettings,
+    getHideSold,
+    setHideSold,
+    normalizeVin,
+    normalizeStock,
+    debounce
+  } = await import(chrome.runtime.getURL('src/common.js'));
+
+  let settings = await getSettings();
+  let { vins, stocks } = await getCache();
+  let hideSold = await getHideSold();
+
+  const VIN_REGEX = /\b[A-HJ-NPR-Z0-9]{17}\b/;
+
+  const processCards = debounce(() => {
+    applyToCards(document);
+  }, 100);
+
+  function applyToCards(root) {
+    const cardSelector = settings.selectors?.card || '';
+    if (!cardSelector) return;
+    const cards = root.querySelectorAll(cardSelector);
+    cards.forEach((card) => {
+      try {
+        annotateCard(card);
+      } catch (error) {
+        console.debug('Inventory Highlighter card error', error);
+      }
+    });
+  }
+
+  function annotateCard(card) {
+    const vin = extractVin(card);
+    const stock = extractStock(card);
+    const isSold = Boolean((vin && vins.has(vin)) || (stock && stocks.has(stock)));
+    toggleCardState(card, isSold);
+  }
+
+  function extractTextBySelector(card, selector) {
+    if (!selector) return '';
+    const el = card.querySelector(selector);
+    if (!el) return '';
+    return el.textContent || '';
+  }
+
+  function extractVin(card) {
+    const fromSelector = extractTextBySelector(card, settings.selectors?.vin);
+    const normalized = normalizeVin(fromSelector);
+    if (normalized) return normalized;
+    const fallback = card.textContent || '';
+    const match = fallback.match(VIN_REGEX);
+    return match ? normalizeVin(match[0]) : '';
+  }
+
+  function extractStock(card) {
+    const fromSelector = extractTextBySelector(card, settings.selectors?.stock);
+    if (fromSelector) {
+      const normalized = normalizeStock(fromSelector);
+      if (normalized) return normalized;
+    }
+    const fallback = card.textContent || '';
+    const stockMatch = fallback.match(/\b(?:STOCK|STK|SKU|Склад|Сток)[:#\s]*([A-Z0-9-]{4,})\b/i);
+    return stockMatch ? normalizeStock(stockMatch[1]) : '';
+  }
+
+  function toggleCardState(card, isSold) {
+    const badgeText = settings.badgeText || 'Sold';
+    if (isSold) {
+      card.classList.add('ih-sold');
+      if (hideSold) {
+        card.classList.add('ih-hidden');
+      } else {
+        card.classList.remove('ih-hidden');
+      }
+      let badge = card.querySelector('.ih-badge');
+      if (!badge) {
+        badge = document.createElement('div');
+        badge.className = 'ih-badge';
+        badge.setAttribute('aria-label', badgeText);
+        card.appendChild(badge);
+      }
+      badge.textContent = badgeText;
+    } else {
+      card.classList.remove('ih-sold', 'ih-hidden');
+      const badge = card.querySelector('.ih-badge');
+      if (badge) {
+        badge.remove();
+      }
+    }
+  }
+
+  function refreshSettings() {
+    getSettings().then((nextSettings) => {
+      settings = nextSettings;
+      processCards();
+    });
+  }
+
+  function refreshCache() {
+    getCache().then((cache) => {
+      vins = cache.vins;
+      stocks = cache.stocks;
+      processCards();
+    });
+  }
+
+  function updateHideSold(value) {
+    hideSold = value;
+    document.querySelectorAll(settings.selectors?.card || '').forEach((card) => {
+      if (card.classList.contains('ih-sold')) {
+        if (hideSold) {
+          card.classList.add('ih-hidden');
+        } else {
+          card.classList.remove('ih-hidden');
+        }
+      }
+    });
+  }
+
+  const observer = new MutationObserver((mutations) => {
+    let shouldProcess = false;
+    mutations.forEach((mutation) => {
+      if (mutation.type === 'childList' && mutation.addedNodes.length) {
+        shouldProcess = true;
+      }
+    });
+    if (shouldProcess) {
+      processCards();
+    }
+  });
+
+  observer.observe(document.body || document.documentElement, {
+    childList: true,
+    subtree: true
+  });
+
+  processCards();
+
+  chrome.runtime.onMessage.addListener((message) => {
+    if (message?.type === 'ih_cache_updated') {
+      refreshCache();
+    }
+    if (message?.type === 'ih_hide_sold_toggled') {
+      updateHideSold(Boolean(message.value));
+    }
+  });
+
+  chrome.storage.onChanged.addListener((changes, areaName) => {
+    if (areaName === 'sync' && changes[STORAGE_KEYS.SETTINGS]) {
+      refreshSettings();
+    }
+    if (areaName === 'local' && changes[STORAGE_KEYS.HIDE_SOLD]) {
+      updateHideSold(changes[STORAGE_KEYS.HIDE_SOLD].newValue);
+    }
+  });
+
+  if (hideSold !== settings.hideSold) {
+    setHideSold(hideSold).catch(() => {});
+  }
+})();

--- a/src/content.js
+++ b/src/content.js
@@ -20,6 +20,10 @@
     applyToCards(document);
   }, 100);
 
+  function usesVinColumn() {
+    return Boolean((settings.columns?.vin || '').trim());
+  }
+
   function applyToCards(root) {
     const cardSelector = settings.selectors?.card || '';
     if (!cardSelector) return;
@@ -34,7 +38,7 @@
   }
 
   function annotateCard(card) {
-    const vin = extractVin(card);
+    const vin = usesVinColumn() ? extractVin(card) : '';
     const stock = extractStock(card);
     const isSold = Boolean((vin && vins.has(vin)) || (stock && stocks.has(stock)));
     toggleCardState(card, isSold);
@@ -48,6 +52,7 @@
   }
 
   function extractVin(card) {
+    if (!usesVinColumn()) return '';
     const fromSelector = extractTextBySelector(card, settings.selectors?.vin);
     const normalized = normalizeVin(fromSelector);
     if (normalized) return normalized;

--- a/src/options/index.html
+++ b/src/options/index.html
@@ -1,0 +1,107 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Inventory Highlighter Options</title>
+    <link rel="stylesheet" href="options.css" />
+  </head>
+  <body>
+    <main>
+      <h1>Inventory Highlighter Options</h1>
+      <form id="options-form">
+        <section>
+          <h2>Data Source</h2>
+          <label>
+            <input type="radio" name="dataSource" value="csv" />
+            Published CSV URL
+          </label>
+          <label class="indent">
+            CSV URL
+            <input type="url" name="csvUrl" placeholder="https://docs.google.com/spreadsheets/d/.../pub?output=csv" />
+          </label>
+          <label>
+            <input type="radio" name="dataSource" value="sheets" />
+            Google Sheets API
+          </label>
+          <div class="indent grid">
+            <label>
+              Spreadsheet ID
+              <input type="text" name="spreadsheetId" />
+            </label>
+            <label>
+              Range
+              <input type="text" name="range" placeholder="Sheet1!A1:C500" />
+            </label>
+            <label>
+              API Key
+              <input type="text" name="apiKey" />
+            </label>
+          </div>
+        </section>
+
+        <section>
+          <h2>Column Names</h2>
+          <div class="grid">
+            <label>
+              VIN column
+              <input type="text" name="vinColumn" />
+            </label>
+            <label>
+              Stock column
+              <input type="text" name="stockColumn" />
+            </label>
+            <label>
+              Status column
+              <input type="text" name="statusColumn" />
+            </label>
+          </div>
+          <label>
+            Sold status values (comma-separated)
+            <input type="text" name="soldValues" placeholder="Sold,SOLD,Delivered" />
+          </label>
+        </section>
+
+        <section>
+          <h2>Page Selectors</h2>
+          <label>
+            Card selector
+            <input type="text" name="cardSelector" />
+          </label>
+          <div class="grid">
+            <label>
+              VIN selector
+              <input type="text" name="vinSelector" />
+            </label>
+            <label>
+              Stock selector
+              <input type="text" name="stockSelector" />
+            </label>
+          </div>
+        </section>
+
+        <section>
+          <h2>Behavior</h2>
+          <div class="grid">
+            <label>
+              Badge text
+              <input type="text" name="badgeText" />
+            </label>
+            <label>
+              Auto refresh (minutes)
+              <input type="number" name="autoRefresh" min="1" />
+            </label>
+          </div>
+          <label class="inline">
+            <input type="checkbox" name="hideSold" /> Hide sold vehicles by default
+          </label>
+        </section>
+
+        <footer>
+          <button type="submit">Save</button>
+          <span id="status"></span>
+        </footer>
+      </form>
+    </main>
+    <script type="module" src="options.js"></script>
+  </body>
+</html>

--- a/src/options/index.html
+++ b/src/options/index.html
@@ -30,7 +30,7 @@
             </label>
             <label>
               Range
-              <input type="text" name="range" placeholder="Sheet1!A1:C500" />
+              <input type="text" name="range" placeholder="Sheet1!A1:G500" />
             </label>
             <label>
               API Key
@@ -43,7 +43,7 @@
           <h2>Column Names</h2>
           <div class="grid">
             <label>
-              VIN column
+              VIN column (optional)
               <input type="text" name="vinColumn" />
             </label>
             <label>
@@ -57,7 +57,7 @@
           </div>
           <label>
             Sold status values (comma-separated)
-            <input type="text" name="soldValues" placeholder="Sold,SOLD,Delivered" />
+            <input type="text" name="soldValues" placeholder="sold" />
           </label>
         </section>
 

--- a/src/options/options.css
+++ b/src/options/options.css
@@ -1,0 +1,94 @@
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  background: #f5f6f8;
+  color: #1f2933;
+  margin: 0;
+  padding: 0;
+}
+
+main {
+  max-width: 720px;
+  margin: 2rem auto;
+  background: #fff;
+  padding: 2rem;
+  border-radius: 0.75rem;
+  box-shadow: 0 8px 24px rgba(15, 23, 42, 0.12);
+}
+
+h1 {
+  margin-top: 0;
+  font-size: 1.75rem;
+}
+
+section {
+  margin-bottom: 1.5rem;
+}
+
+section h2 {
+  margin-bottom: 0.5rem;
+  font-size: 1.2rem;
+}
+
+label {
+  display: block;
+  margin-bottom: 0.75rem;
+  font-weight: 500;
+}
+
+label input[type='text'],
+label input[type='url'],
+label input[type='number'] {
+  display: block;
+  width: 100%;
+  padding: 0.5rem;
+  margin-top: 0.35rem;
+  border: 1px solid #d0d7de;
+  border-radius: 0.5rem;
+  font-size: 0.95rem;
+}
+
+label.inline {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-weight: 600;
+}
+
+label.inline input[type='checkbox'] {
+  margin: 0;
+}
+
+.indent {
+  margin-left: 1.5rem;
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 1rem;
+}
+
+footer {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+button[type='submit'] {
+  background: #2563eb;
+  color: #fff;
+  border: none;
+  border-radius: 0.5rem;
+  padding: 0.6rem 1.2rem;
+  font-size: 1rem;
+  cursor: pointer;
+}
+
+button[type='submit']:hover {
+  background: #1d4ed8;
+}
+
+#status {
+  font-size: 0.9rem;
+  color: #059669;
+}

--- a/src/options/options.js
+++ b/src/options/options.js
@@ -1,0 +1,96 @@
+import {
+  DEFAULT_SETTINGS,
+  getSettings,
+  saveSettings,
+  setHideSold
+} from '../common.js';
+
+const form = document.getElementById('options-form');
+const statusEl = document.getElementById('status');
+
+init();
+
+async function init() {
+  const settings = await getSettings();
+  populateForm(settings);
+}
+
+function populateForm(settings) {
+  const dataSource = settings.dataSource || DEFAULT_SETTINGS.dataSource;
+  form.elements['dataSource'].value = dataSource;
+  form.querySelectorAll("input[name='dataSource']").forEach((input) => {
+    input.checked = input.value === dataSource;
+  });
+  form.elements['csvUrl'].value = settings.csvUrl || '';
+  form.elements['spreadsheetId'].value = settings.sheets?.spreadsheetId || '';
+  form.elements['range'].value = settings.sheets?.range || '';
+  form.elements['apiKey'].value = settings.sheets?.apiKey || '';
+
+  form.elements['vinColumn'].value = settings.columns?.vin || DEFAULT_SETTINGS.columns.vin;
+  form.elements['stockColumn'].value = settings.columns?.stock || DEFAULT_SETTINGS.columns.stock;
+  form.elements['statusColumn'].value = settings.columns?.status || DEFAULT_SETTINGS.columns.status;
+  form.elements['soldValues'].value = (settings.soldValues || []).join(',');
+
+  form.elements['cardSelector'].value = settings.selectors?.card || DEFAULT_SETTINGS.selectors.card;
+  form.elements['vinSelector'].value = settings.selectors?.vin || DEFAULT_SETTINGS.selectors.vin;
+  form.elements['stockSelector'].value = settings.selectors?.stock || DEFAULT_SETTINGS.selectors.stock;
+
+  form.elements['badgeText'].value = settings.badgeText || DEFAULT_SETTINGS.badgeText;
+  form.elements['autoRefresh'].value = settings.autoRefreshMinutes || DEFAULT_SETTINGS.autoRefreshMinutes;
+  form.elements['hideSold'].checked = Boolean(settings.hideSold);
+}
+
+form.addEventListener('submit', async (event) => {
+  event.preventDefault();
+  const formData = new FormData(form);
+  const dataSource = formData.get('dataSource') || DEFAULT_SETTINGS.dataSource;
+  const csvUrl = formData.get('csvUrl')?.trim();
+  const sheets = {
+    spreadsheetId: formData.get('spreadsheetId')?.trim() || '',
+    range: formData.get('range')?.trim() || '',
+    apiKey: formData.get('apiKey')?.trim() || ''
+  };
+  const columns = {
+    vin: formData.get('vinColumn')?.trim() || DEFAULT_SETTINGS.columns.vin,
+    stock: formData.get('stockColumn')?.trim() || DEFAULT_SETTINGS.columns.stock,
+    status: formData.get('statusColumn')?.trim() || DEFAULT_SETTINGS.columns.status
+  };
+  const soldValues = (formData.get('soldValues') || '')
+    .split(',')
+    .map((value) => value.trim())
+    .filter(Boolean);
+  const selectors = {
+    card: formData.get('cardSelector')?.trim() || DEFAULT_SETTINGS.selectors.card,
+    vin: formData.get('vinSelector')?.trim() || DEFAULT_SETTINGS.selectors.vin,
+    stock: formData.get('stockSelector')?.trim() || DEFAULT_SETTINGS.selectors.stock
+  };
+  const badgeText = formData.get('badgeText')?.trim() || DEFAULT_SETTINGS.badgeText;
+  const autoRefreshMinutes = Math.max(1, Number(formData.get('autoRefresh')) || DEFAULT_SETTINGS.autoRefreshMinutes);
+  const hideSold = formData.get('hideSold') === 'on';
+
+  const settings = {
+    dataSource,
+    csvUrl,
+    sheets,
+    columns,
+    soldValues,
+    selectors,
+    badgeText,
+    autoRefreshMinutes,
+    hideSold
+  };
+
+  await saveSettings(settings);
+  await setHideSold(hideSold);
+  await chrome.runtime.sendMessage({ type: 'ih_settings_updated' }).catch(() => {});
+  statusEl.textContent = 'Saved!';
+  setTimeout(() => {
+    statusEl.textContent = '';
+  }, 2000);
+});
+
+form.querySelectorAll("input[name='dataSource']").forEach((input) => {
+  input.addEventListener('change', () => {
+    form.elements['dataSource'].value = input.value;
+  });
+});

--- a/src/popup/popup.css
+++ b/src/popup/popup.css
@@ -1,0 +1,57 @@
+body {
+  margin: 0;
+  padding: 0;
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  background: #111827;
+  color: #f9fafb;
+  width: 260px;
+}
+
+main {
+  padding: 1rem 1.25rem;
+}
+
+h1 {
+  margin: 0 0 0.75rem;
+  font-size: 1.1rem;
+}
+
+button#refresh {
+  width: 100%;
+  padding: 0.6rem;
+  border: none;
+  border-radius: 0.5rem;
+  background: #2563eb;
+  color: #fff;
+  font-size: 0.95rem;
+  font-weight: 600;
+  cursor: pointer;
+  margin-bottom: 0.75rem;
+}
+
+button#refresh:hover {
+  background: #1d4ed8;
+}
+
+.switch {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 0.5rem;
+}
+
+.switch input[type='checkbox'] {
+  width: 1rem;
+  height: 1rem;
+}
+
+.meta {
+  font-size: 0.8rem;
+  color: #cbd5f5;
+}
+
+#message {
+  min-height: 1rem;
+  font-size: 0.85rem;
+  color: #34d399;
+}

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Inventory Highlighter</title>
+    <link rel="stylesheet" href="popup.css" />
+  </head>
+  <body>
+    <main>
+      <h1>Inventory Highlighter</h1>
+      <button id="refresh">Refresh now</button>
+      <label class="switch">
+        <input type="checkbox" id="hideSold" />
+        <span>Hide sold vehicles</span>
+      </label>
+      <p class="meta">Last sync: <span id="lastSync">Loading…</span></p>
+      <p id="message" role="status"></p>
+    </main>
+    <script type="module" src="popup.js"></script>
+  </body>
+</html>

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -1,0 +1,69 @@
+import {
+  getCache,
+  getHideSold,
+  setHideSold,
+  formatTime
+} from '../common.js';
+
+const refreshButton = document.getElementById('refresh');
+const hideSoldToggle = document.getElementById('hideSold');
+const lastSyncEl = document.getElementById('lastSync');
+const messageEl = document.getElementById('message');
+
+init();
+
+async function init() {
+  const hideSold = await getHideSold();
+  hideSoldToggle.checked = Boolean(hideSold);
+  await updateLastSync();
+}
+
+refreshButton.addEventListener('click', async () => {
+  setBusy(true, 'Refreshing…');
+  try {
+    const response = await chrome.runtime.sendMessage({ type: 'ih_refresh_now' });
+    if (response?.success) {
+      await updateLastSync(response.lastSync);
+      setBusy(false, `Synced ${new Date(response.lastSync).toLocaleTimeString()}`);
+    } else {
+      throw new Error(response?.error || 'Unknown error');
+    }
+  } catch (error) {
+    console.error('Inventory Highlighter refresh failed', error);
+    setBusy(false, error.message || 'Refresh failed');
+  }
+});
+
+hideSoldToggle.addEventListener('change', async (event) => {
+  const value = event.target.checked;
+  await setHideSold(value);
+  messageEl.textContent = value ? 'Sold vehicles hidden' : 'Sold vehicles visible';
+  setTimeout(() => {
+    messageEl.textContent = '';
+  }, 2000);
+});
+
+async function updateLastSync(forceValue) {
+  if (forceValue) {
+    lastSyncEl.textContent = formatTime(forceValue);
+    return;
+  }
+  const cache = await getCache();
+  lastSyncEl.textContent = formatTime(cache.lastSync);
+}
+
+function setBusy(isBusy, message) {
+  refreshButton.disabled = isBusy;
+  refreshButton.textContent = isBusy ? 'Refreshing…' : 'Refresh now';
+  if (message) {
+    messageEl.textContent = message;
+  } else {
+    messageEl.textContent = '';
+  }
+}
+
+chrome.runtime.onMessage.addListener((message) => {
+  if (message?.type === 'ih_cache_updated') {
+    updateLastSync(message.lastSync);
+  }
+});

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,0 +1,24 @@
+.ih-sold {
+  filter: grayscale(0.6) brightness(0.8);
+  transition: filter 0.3s ease, opacity 0.3s ease;
+  position: relative;
+}
+
+.ih-hidden {
+  display: none !important;
+}
+
+.ih-badge {
+  position: absolute;
+  top: 0.5rem;
+  right: 0.5rem;
+  padding: 0.25rem 0.5rem;
+  border-radius: 0.375rem;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  background: rgba(0, 0, 0, 0.85);
+  color: #fff;
+  pointer-events: none;
+  z-index: 100;
+}

--- a/tests/smoke.mjs
+++ b/tests/smoke.mjs
@@ -2,28 +2,26 @@ import assert from 'assert/strict';
 import {
   parseCsv,
   buildLookups,
-  normalizeVin,
   normalizeStock,
   DEFAULT_SETTINGS
 } from '../src/common.js';
 
-const sampleCsv = `VIN,Stock,Status\nJM3KK1WY0R1100001,STK-001,Sold\n1HGCM82633A004352,STK-002,Available`;
+const sampleCsv = `Stock,Comment\nSTK-001,sold\nSTK-002,available`;
 
 const rows = parseCsv(sampleCsv);
 assert.equal(rows.length, 2, 'CSV parser should return 2 data rows');
-assert.equal(rows[0].VIN, 'JM3KK1WY0R1100001');
-assert.equal(rows[1].Status, 'Available');
+assert.equal(rows[0].Stock, 'STK-001');
+assert.equal(rows[1].Comment, 'available');
 
 const { vinSet, stockSet } = buildLookups(rows, {
   columns: DEFAULT_SETTINGS.columns,
-  soldValues: ['Sold']
+  soldValues: ['sold']
 });
 
-assert(vinSet.has(normalizeVin('JM3KK1WY0R1100001')),
-  'VIN lookup should include sold VIN');
-assert(!vinSet.has(normalizeVin('1HGCM82633A004352')),
-  'VIN lookup should not include available VIN');
+assert.equal(vinSet.size, 0, 'VIN lookup should remain empty when no VIN column is configured.');
 assert(stockSet.has(normalizeStock('STK-001')),
   'Stock lookup should include sold stock');
+assert(!stockSet.has(normalizeStock('STK-002')),
+  'Stock lookup should not include available stock');
 
 console.log('Smoke test passed: CSV parsing and lookup generation work as expected.');

--- a/tests/smoke.mjs
+++ b/tests/smoke.mjs
@@ -1,0 +1,29 @@
+import assert from 'assert/strict';
+import {
+  parseCsv,
+  buildLookups,
+  normalizeVin,
+  normalizeStock,
+  DEFAULT_SETTINGS
+} from '../src/common.js';
+
+const sampleCsv = `VIN,Stock,Status\nJM3KK1WY0R1100001,STK-001,Sold\n1HGCM82633A004352,STK-002,Available`;
+
+const rows = parseCsv(sampleCsv);
+assert.equal(rows.length, 2, 'CSV parser should return 2 data rows');
+assert.equal(rows[0].VIN, 'JM3KK1WY0R1100001');
+assert.equal(rows[1].Status, 'Available');
+
+const { vinSet, stockSet } = buildLookups(rows, {
+  columns: DEFAULT_SETTINGS.columns,
+  soldValues: ['Sold']
+});
+
+assert(vinSet.has(normalizeVin('JM3KK1WY0R1100001')),
+  'VIN lookup should include sold VIN');
+assert(!vinSet.has(normalizeVin('1HGCM82633A004352')),
+  'VIN lookup should not include available VIN');
+assert(stockSet.has(normalizeStock('STK-001')),
+  'Stock lookup should include sold stock');
+
+console.log('Smoke test passed: CSV parsing and lookup generation work as expected.');


### PR DESCRIPTION
## Summary
- remove the packaged PNG icon assets that triggered PR tooling binary file errors
- update the manifest to reference only the popup while omitting default icons
- document the requirement to add custom icons in the README before publishing
- add a Node-based smoke test to validate CSV parsing and lookup generation and reference it in the testing checklist

## Testing
- node tests/smoke.mjs

------
https://chatgpt.com/codex/tasks/task_e_68def83177a88323847d7623b59c96ec