### PR TITLE
Improve stock value extraction

### DIFF
--- a/src/content.js
+++ b/src/content.js
@@ -7,6 +7,7 @@
     setHideSold,
     normalizeVin,
     normalizeStock,
+    extractStockValue,
     debounce
   } = await import(chrome.runtime.getURL('src/common.js'));
 
@@ -58,13 +59,13 @@
 
   function extractStock(card) {
     const fromSelector = extractTextBySelector(card, settings.selectors?.stock);
-    if (fromSelector) {
-      const normalized = normalizeStock(fromSelector);
+    const selectorValue = extractStockValue(fromSelector);
+    if (selectorValue) {
+      const normalized = normalizeStock(selectorValue);
       if (normalized) return normalized;
     }
-    const fallback = card.textContent || '';
-    const stockMatch = fallback.match(/\b(?:STOCK|STK|SKU|Склад|Сток)[:#\s]*([A-Z0-9-]{4,})\b/i);
-    return stockMatch ? normalizeStock(stockMatch[1]) : '';
+    const fallbackValue = extractStockValue(card.textContent || '');
+    return fallbackValue ? normalizeStock(fallbackValue) : '';
   }
 
   function toggleCardState(card, isSold) {

--- a/tests/smoke.mjs
+++ b/tests/smoke.mjs
@@ -1,0 +1,9 @@
+import assert from 'node:assert/strict';
+import { extractStockValue, normalizeStock } from '../src/common.js';
+
+const rawStock = 'Stock: 28996B';
+const normalized = normalizeStock(extractStockValue(rawStock));
+
+assert.equal(normalized, '28996B', 'stock label should be stripped before normalization');
+
+console.log('Smoke tests passed');


### PR DESCRIPTION
## Summary
- add shared stock parsing helpers so stock labels are removed before normalization
- use the shared parser in the content script to capture only the stock identifier
- add a smoke test that verifies labelled stock values normalize correctly

## Testing
- `node tests/smoke.mjs`


------
https://chatgpt.com/codex/tasks/task_e_68e18177f8f48323b9786914dd4a71d2