### PR TITLE
Strip labels from stock numbers before matching

### DIFF
--- a/src/common.js
+++ b/src/common.js
@@ -1,5 +1,7 @@
 // Common utilities shared by background, content, popup, and options scripts.
 
+const STOCK_LABEL_TOKENS = new Set(['STOCK', 'STK', 'SKU', 'СКЛАД', 'СТОК']);
+
 export const DEFAULT_SETTINGS = {
   dataSource: 'csv', // 'csv' or 'sheets'
   csvUrl: '',
@@ -40,6 +42,31 @@ export function normalizeVin(vin = '') {
 
 export function normalizeStock(stock = '') {
   return stock.trim().toUpperCase();
+}
+
+export function stripStockLabel(text = '') {
+  if (!text) return '';
+  const colonIndex = text.indexOf(':');
+  const hashIndex = text.indexOf('#');
+  let separatorIndex = -1;
+  if (colonIndex !== -1 && hashIndex !== -1) {
+    separatorIndex = Math.min(colonIndex, hashIndex);
+  } else {
+    separatorIndex = colonIndex !== -1 ? colonIndex : hashIndex;
+  }
+  if (separatorIndex !== -1) {
+    return text.slice(separatorIndex + 1).trimStart();
+  }
+  return text;
+}
+
+export function extractStockValue(text = '') {
+  const stripped = stripStockLabel(text);
+  if (!stripped) return '';
+  const matches = stripped.match(/[A-Z0-9-]{4,}/gi);
+  if (!matches) return '';
+  const candidate = matches.find((token) => !STOCK_LABEL_TOKENS.has(token.toUpperCase()));
+  return candidate ? normalizeStock(candidate) : '';
 }
 
 export function parseCsv(text) {

--- a/src/content.js
+++ b/src/content.js
@@ -7,6 +7,7 @@
     setHideSold,
     normalizeVin,
     normalizeStock,
+    extractStockValue,
     debounce
   } = await import(chrome.runtime.getURL('src/common.js'));
 
@@ -59,12 +60,15 @@
   function extractStock(card) {
     const fromSelector = extractTextBySelector(card, settings.selectors?.stock);
     if (fromSelector) {
-      const normalized = normalizeStock(fromSelector);
+      const normalized = extractStockValue(fromSelector);
       if (normalized) return normalized;
     }
     const fallback = card.textContent || '';
-    const stockMatch = fallback.match(/\b(?:STOCK|STK|SKU|Склад|Сток)[:#\s]*([A-Z0-9-]{4,})\b/i);
-    return stockMatch ? normalizeStock(stockMatch[1]) : '';
+    const stockMatch = fallback.match(/\b(?:STOCK|STK|SKU|Склад|Сток)[:#\s-]*([A-Z0-9-]{4,})\b/i);
+    if (stockMatch) {
+      return normalizeStock(stockMatch[1]);
+    }
+    return extractStockValue(fallback);
   }
 
   function toggleCardState(card, isSold) {

--- a/tests/smoke.mjs
+++ b/tests/smoke.mjs
@@ -1,0 +1,7 @@
+import assert from 'node:assert/strict';
+import { extractStockValue } from '../src/common.js';
+
+const result = extractStockValue('Stock: 28996B');
+assert.equal(result, '28996B', 'Stock labels should be removed before normalization');
+
+console.log('Smoke tests passed.');


### PR DESCRIPTION
## Summary
- add shared helpers to strip label prefixes and find stock tokens safely
- update the content script to reuse the shared logic and avoid matching the label text
- add a smoke test covering a labelled stock number to guard against regressions

## Testing
- node tests/smoke.mjs

------
https://chatgpt.com/codex/tasks/task_e_68e18869b0bc8323b4da0e3b90b4fdf1